### PR TITLE
feat: Enable monitoring namespace and opensearch helm release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file. See [commit
 
 ## [2.0.0-alpha.13](///compare/v2.0.0-alpha.12...v2.0.0-alpha.13) (2024-10-23)
 
+
+### Features
+
+* **atlantis.yaml:** update workflow and workspace configuration 28f7181
+
+## [2.0.0-alpha.13](///compare/v2.0.0-alpha.12...v2.0.0-alpha.13) (2024-10-23)
+
 ## [2.0.0-alpha.12](///compare/v2.0.0-alpha.11...v2.0.0-alpha.12) (2024-10-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [2.0.0-alpha.12](///compare/v2.0.0-alpha.11...v2.0.0-alpha.12) (2024-10-23)
+
+
+### Bug Fixes
+
+* refactor atlantis.yaml 1b8c012
+
 ## [2.0.0-alpha.11](///compare/v2.0.0-alpha.10...v2.0.0-alpha.11) (2024-10-23)
 
 

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -21,11 +21,29 @@ workflows:
     plan:
       steps:
         - init:
-            extra_args: ["-var", "github_user=${ATLANTIS_GH_USER}", "-var", "github_secret=${ATLANTIS_GH_SECRET}", "-var", "github_token=${ATLANTIS_GH_TOKEN}"]
+            extra_args:
+              - "-var"
+              - "github_user=${ATLANTIS_GH_USER}"
+              - "-var"
+              - "github_secret=${ATLANTIS_GH_SECRET}"
+              - "-var"
+              - "github_token=${ATLANTIS_GH_TOKEN}"
         - plan:
-            extra_args: ["-var", "github_user=${ATLANTIS_GH_USER}", "-var", "github_secret=${ATLANTIS_GH_SECRET}", "-var", "github_token=${ATLANTIS_GH_TOKEN}"]
+            extra_args:
+              - "-var"
+              - "github_user=${ATLANTIS_GH_USER}"
+              - "-var"
+              - "github_secret=${ATLANTIS_GH_SECRET}"
+              - "-var"
+              - "github_token=${ATLANTIS_GH_TOKEN}"
 
     apply:
       steps:
         - apply:
-            extra_args: ["-var", "github_user=${ATLANTIS_GH_USER}", "-var", "github_secret=${ATLANTIS_GH_SECRET}", "-var", "github_token=${ATLANTIS_GH_TOKEN}"]
+            extra_args:
+              - "-var"
+              - "github_user=${ATLANTIS_GH_USER}"
+              - "-var"
+              - "github_secret=${ATLANTIS_GH_SECRET}"
+              - "-var"
+              - "github_token=${ATLANTIS_GH_TOKEN}"

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -8,42 +8,43 @@ parallel_apply: true
 projects:
   - name: tf-atlantis-elk
     dir: ./terraform
-    workflow: custom
+    workspace: default
     autoplan:
       enabled: true
       when_modified:
         - "*.tf"
         - "*.tfvars"
         - ".terraform.lock.hcl"
+    workflow: custom
 
 workflows:
   custom:
     plan:
       steps:
-        - init:
-            extra_args:
-              - "-var"
-              - "github_user=${ATLANTIS_GH_USER}"
-              - "-var"
-              - "github_secret=${ATLANTIS_GH_SECRET}"
-              - "-var"
-              - "github_token=${ATLANTIS_GH_TOKEN}"
-        - plan:
-            extra_args:
-              - "-var"
-              - "github_user=${ATLANTIS_GH_USER}"
-              - "-var"
-              - "github_secret=${ATLANTIS_GH_SECRET}"
-              - "-var"
-              - "github_token=${ATLANTIS_GH_TOKEN}"
+      - init:
+          extra_args:
+            - "-var"
+            - "github_user=${ATLANTIS_GH_USER}"
+            - "-var"
+            - "github_secret=${ATLANTIS_GH_SECRET}"
+            - "-var"
+            - "github_token=${ATLANTIS_GH_TOKEN}"
+      - plan:
+          extra_args:
+            - "-var"
+            - "github_user=${ATLANTIS_GH_USER}"
+            - "-var"
+            - "github_secret=${ATLANTIS_GH_SECRET}"
+            - "-var"
+            - "github_token=${ATLANTIS_GH_TOKEN}"
 
     apply:
       steps:
-        - apply:
-            extra_args:
-              - "-var"
-              - "github_user=${ATLANTIS_GH_USER}"
-              - "-var"
-              - "github_secret=${ATLANTIS_GH_SECRET}"
-              - "-var"
-              - "github_token=${ATLANTIS_GH_TOKEN}"
+      - apply:
+          extra_args:
+            - "-var"
+            - "github_user=${ATLANTIS_GH_USER}"
+            - "-var"
+            - "github_secret=${ATLANTIS_GH_SECRET}"
+            - "-var"
+            - "github_token=${ATLANTIS_GH_TOKEN}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,11 +9,11 @@ resource "kubernetes_namespace" "atlantis" {
   }
 }
 
-# resource "kubernetes_namespace" "monitoring" {
-#   metadata {
-#     name = "monitoring"
-#   }
-# }
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = "monitoring"
+  }
+}
 
 resource "helm_release" "atlantis" {
   name       = "atlantis"
@@ -39,11 +39,11 @@ resource "helm_release" "atlantis" {
   }
 }
 
-# resource "helm_release" "opensearch" {
-#   name       = "opensearch"
-#   repository = "https://charts.bitnami.com/bitnami"
-#   chart      = "opensearch"
-#   namespace  = "monitoring"
+resource "helm_release" "opensearch" {
+  name       = "opensearch"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "opensearch"
+  namespace  = "monitoring"
 
-#   values = [file("${path.module}/../helm/opensearch/values.yaml")]
-# }
+  values = [file("${path.module}/../helm/opensearch/values.yaml")]
+}


### PR DESCRIPTION
- Uncommented the "kubernetes_namespace" block for "monitoring"
- Uncommented the "helm_release" block for "opensearch" in the "monitoring" namespace
