### PR TITLE
32 substitution error during Atlantis plan phase

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,7 @@
-# provider "kubernetes" {
-#   config_path   = "~/.kube/config"
-#   config_context = ""
-# }
+provider "kubernetes" {
+  config_path   = "~/.kube/config"
+  config_context = ""
+}
 
 resource "kubernetes_namespace" "atlantis" {
   metadata {
@@ -9,11 +9,11 @@ resource "kubernetes_namespace" "atlantis" {
   }
 }
 
-# resource "kubernetes_namespace" "monitoring" {
-#   metadata {
-#     name = "monitoring"
-#   }
-# }
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = "monitoring"
+  }
+}
 
 resource "helm_release" "atlantis" {
   name       = "atlantis"
@@ -39,11 +39,11 @@ resource "helm_release" "atlantis" {
   }
 }
 
-# resource "helm_release" "opensearch" {
-#   name       = "opensearch"
-#   repository = "https://charts.bitnami.com/bitnami"
-#   chart      = "opensearch"
-#   namespace  = "monitoring"
+resource "helm_release" "opensearch" {
+  name       = "opensearch"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "opensearch"
+  namespace  = "monitoring"
 
-#   values = [file("${path.module}/../helm/opensearch/values.yaml")]
-# }
+  values = [file("${path.module}/../helm/opensearch/values.yaml")]
+}


### PR DESCRIPTION
- Uncommented the Kubernetes provider configuration
- Enabled 'monitoring' namespace in Kubernetes
- Activated helm release for 'opensearch' in the 'monitoring' namespace
