### PR TITLE
feat(terraform): enable monitoring namespace and opensearch helm release

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,11 +12,11 @@ resource "kubernetes_namespace" "atlantis" {
   }
 }
 
-# resource "kubernetes_namespace" "monitoring" {
-#   metadata {
-#     name = "monitoring"
-#   }
-# }
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = "monitoring"
+  }
+}
 
 resource "helm_release" "atlantis" {
   name       = "atlantis"
@@ -47,11 +47,11 @@ resource "helm_release" "atlantis" {
   }
 }
 
-# resource "helm_release" "opensearch" {
-#   name       = "opensearch"
-#   repository = "https://charts.bitnami.com/bitnami"
-#   chart      = "opensearch"
-#   namespace  = "monitoring"
+resource "helm_release" "opensearch" {
+  name       = "opensearch"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "opensearch"
+  namespace  = "monitoring"
 
-#   values = [file("${path.module}/../helm/opensearch/values.yaml")]
-# }
+  values = [file("${path.module}/../helm/opensearch/values.yaml")]
+}


### PR DESCRIPTION
- Uncommented the kubernetes_namespace resource for "monitoring"
- Enabled the helm_release for "opensearch" in the "monitoring" namespace
- Added values from external yaml file to the opensearch helm release configuration
