### PR TITLE
feat: Enable monitoring namespace and opensearch helm release

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -24,17 +24,9 @@ workflows:
                 }
               }
             }' > ~/.terraform.d/credentials.tfrc.json
-      - init:
-          # extra_args:
-          #   - "-var"
-          #   - "github_user=${ATLANTIS_GH_USER}"
-          #   - "-var"
-          #   - "github_secret=${ATLANTIS_GH_SECRET}"
-          #   - "-var"
-          #   - "github_token=${ATLANTIS_GH_TOKEN}"
-          #   - "-var"
-          #   - "hcp_token=${HCP_TOKEN}"
           output: hide
+
+      - init
 
       - plan:
           extra_args:

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -46,7 +46,6 @@ workflows:
             - "github_token=${ATLANTIS_GH_TOKEN}"
             - "-var"
             - "hcp_token=${HCP_TOKEN}"
-          output: hide
 
     apply:
       steps:
@@ -71,4 +70,3 @@ workflows:
             - "github_token=${ATLANTIS_GH_TOKEN}"
             - "-var"
             - "hcp_token=${HCP_TOKEN}"
-        output: hide

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,11 +12,11 @@ resource "kubernetes_namespace" "atlantis" {
   }
 }
 
-# resource "kubernetes_namespace" "monitoring" {
-#   metadata {
-#     name = "monitoring"
-#   }
-# }
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = "monitoring"
+  }
+}
 
 resource "helm_release" "atlantis" {
   name       = "atlantis"
@@ -47,11 +47,11 @@ resource "helm_release" "atlantis" {
   }
 }
 
-# resource "helm_release" "opensearch" {
-#   name       = "opensearch"
-#   repository = "https://charts.bitnami.com/bitnami"
-#   chart      = "opensearch"
-#   namespace  = "monitoring"
+resource "helm_release" "opensearch" {
+  name       = "opensearch"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "opensearch"
+  namespace  = "monitoring"
 
-#   values = [file("${path.module}/../helm/opensearch/values.yaml")]
-# }
+  values = [file("${path.module}/../helm/opensearch/values.yaml")]
+}


### PR DESCRIPTION
- Uncommented the kubernetes_namespace block for "monitoring"
- Enabled helm_release for "opensearch" in the "monitoring" namespace
- Set values from a file located at "${path.module}/../helm/opensearch/values.yaml"
