### PR TITLE
feat: Enable Kubernetes namespace and Helm release for OpenSearch

### DIFF
--- a/deploy/opensearch/terraform/main.tf
+++ b/deploy/opensearch/terraform/main.tf
@@ -1,14 +1,14 @@
-# resource "kubernetes_namespace" "monitoring" {
-#   metadata {
-#     name = "monitoring"
-#   }
-# }
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = "monitoring"
+  }
+}
 
-# resource "helm_release" "opensearch" {
-#   name       = "opensearch"
-#   repository = "https://charts.bitnami.com/bitnami"
-#   chart      = "opensearch"
-#   namespace  = "monitoring"
+resource "helm_release" "opensearch" {
+  name       = "opensearch"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "opensearch"
+  namespace  = "monitoring"
 
-#   values = [file("${path.module}/../helm/values.yaml")]
-# }
+  values = [file("${path.module}/../helm/values.yaml")]
+}


### PR DESCRIPTION
- Uncommented the Kubernetes namespace "monitoring"
- Enabled Helm release for OpenSearch in the "monitoring" namespace
- Set values from a file located at "${path.module}/../helm/values.yaml"
